### PR TITLE
Partial fix for Issue #8

### DIFF
--- a/src/drp/js/themes/drp/css/metacatui.css
+++ b/src/drp/js/themes/drp/css/metacatui.css
@@ -415,10 +415,12 @@ select {
     }
 
     #Footer .footer-logos-list img{
+        display: block;
         max-width: 211px;
-        width: 100%;
         max-height: 44px;
-        height: max-content;
+        width: 100%;
+        height: auto;
+        aspect-ratio: auto;
     }
 
     .mapMode footer {

--- a/src/drp/js/themes/drp/css/metacatui.css
+++ b/src/drp/js/themes/drp/css/metacatui.css
@@ -415,12 +415,9 @@ select {
     }
 
     #Footer .footer-logos-list img{
-        display: block;
         max-width: 211px;
         max-height: 44px;
         width: 100%;
-        height: auto;
-        aspect-ratio: auto;
     }
 
     .mapMode footer {

--- a/src/drp/js/themes/drp/css/metacatui.responsive.css
+++ b/src/drp/js/themes/drp/css/metacatui.responsive.css
@@ -19,6 +19,12 @@ and (max-width : 480px) {
     }
 }
 
+@media only screen and (min-width: 900px){
+    #Footer .footer-logos-list img {
+        width: auto;
+        height: auto;
+    }
+}
 
 @media only screen and (max-width : 800px) {
   .has-temporary-message #Content {


### PR DESCRIPTION
Fixing branding logo aspect ratio skew on screens wider than 900 pixels. Still working on a fix for narrower pages. Changes are simple—just removing `height: max-content;` from images in the footer and adding a clause in `metacatui.responsive.css` that specifies auto height and width for footer images when the page width exceeds 900px.

Full issue is here:
- #8