### PR TITLE
Add canonical dataset section to all themes [⭐️ MERGE WITH METACATUI 2.32.0 RELEASE ⭐️]

### DIFF
--- a/src/cerp/js/themes/cerp/templates/metadata/metadataOverview.html
+++ b/src/cerp/js/themes/cerp/templates/metadata/metadataOverview.html
@@ -59,3 +59,11 @@
     list any additional identifiers that can be used to locate or label the dataset here.</p>
     <p class="notification" data-category="alternateIdentifier"></p>
 </div>
+
+<div class="canonical-id basic-text-container" data-category="canonicalDataset">
+	<h5>Canonical Dataset <i class="required-icon hidden" data-category="canonicalDataset"></i></h5>
+	<p class="subtle">If this dataset is essentially a duplicate of a version
+	stored elsewhere, provide the ID of the original dataset here. This must be a
+	DOI or URL</p>
+	<p class="notification" data-category="canonicalDataset"></p>
+</div>

--- a/src/drp/js/themes/drp/templates/metadata/metadataOverview.html
+++ b/src/drp/js/themes/drp/templates/metadata/metadataOverview.html
@@ -79,3 +79,11 @@
     list any additional identifiers that can be used to locate or label the dataset here.</p>
     <p class="notification" data-category="alternateIdentifier"></p>
 </div>
+
+<div class="canonical-id basic-text-container" data-category="canonicalDataset">
+	<h5>Canonical Dataset <i class="required-icon hidden" data-category="canonicalDataset"></i></h5>
+	<p class="subtle">If this dataset is essentially a duplicate of a version
+	stored elsewhere, provide the ID of the original dataset here. This must be a
+	DOI or URL</p>
+	<p class="notification" data-category="canonicalDataset"></p>
+</div>

--- a/src/opc/js/themes/opc/templates/metadata/metadataOverview.html
+++ b/src/opc/js/themes/opc/templates/metadata/metadataOverview.html
@@ -94,3 +94,11 @@
     list any additional identifiers that can be used to locate or label the dataset here.</p>
     <p class="notification" data-category="alternateIdentifier"></p>
 </div>
+
+<div class="canonical-id basic-text-container" data-category="canonicalDataset">
+	<h5>Canonical Dataset <i class="required-icon hidden" data-category="canonicalDataset"></i></h5>
+	<p class="subtle">If this dataset is essentially a duplicate of a version
+	stored elsewhere, provide the ID of the original dataset here. This must be a
+	DOI or URL</p>
+	<p class="notification" data-category="canonicalDataset"></p>
+</div>

--- a/src/sctld/js/themes/sctld/templates/metadata/metadataOverview.html
+++ b/src/sctld/js/themes/sctld/templates/metadata/metadataOverview.html
@@ -90,3 +90,11 @@
     list any additional identifiers that can be used to locate or label the dataset here.</p>
     <p class="notification" data-category="alternateIdentifier"></p>
 </div>
+
+<div class="canonical-id basic-text-container" data-category="canonicalDataset">
+	<h5>Canonical Dataset <i class="required-icon hidden" data-category="canonicalDataset"></i></h5>
+	<p class="subtle">If this dataset is essentially a duplicate of a version
+	stored elsewhere, provide the ID of the original dataset here. This must be a
+	DOI or URL</p>
+	<p class="notification" data-category="canonicalDataset"></p>
+</div>

--- a/src/smithsonian/js/themes/smithsonian/templates/metadata/metadataOverview.html
+++ b/src/smithsonian/js/themes/smithsonian/templates/metadata/metadataOverview.html
@@ -90,3 +90,11 @@
     list any additional identifiers that can be used to locate or label the dataset here.</p>
     <p class="notification" data-category="alternateIdentifier"></p>
 </div>
+
+<div class="canonical-id basic-text-container" data-category="canonicalDataset">
+	<h5>Canonical Dataset <i class="required-icon hidden" data-category="canonicalDataset"></i></h5>
+	<p class="subtle">If this dataset is essentially a duplicate of a version
+	stored elsewhere, provide the ID of the original dataset here. This must be a
+	DOI or URL</p>
+	<p class="notification" data-category="canonicalDataset"></p>
+</div>

--- a/src/theme-boilerplate/js/themes/theme-boilerplate/templates/metadata/metadataOverview.html
+++ b/src/theme-boilerplate/js/themes/theme-boilerplate/templates/metadata/metadataOverview.html
@@ -90,3 +90,11 @@
     list any additional identifiers that can be used to locate or label the dataset here.</p>
     <p class="notification" data-category="alternateIdentifier"></p>
 </div>
+
+<div class="canonical-id basic-text-container" data-category="canonicalDataset">
+	<h5>Canonical Dataset <i class="required-icon hidden" data-category="canonicalDataset"></i></h5>
+	<p class="subtle">If this dataset is essentially a duplicate of a version
+	stored elsewhere, provide the ID of the original dataset here. This must be a
+	DOI or URL</p>
+	<p class="notification" data-category="canonicalDataset"></p>
+</div>


### PR DESCRIPTION
In the editor, add a section for identifying the authoritative dataset for the metadata record. This was added to the metadataOverview.html template for all themes.

Related to https://github.com/NCEAS/metacatui/issues/2542

This PR should be merged with the next release of MetacatUI, and all applicable themes should be updated in production.